### PR TITLE
Enable sourcemaps in rollup config by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ There are some existing React library boilerplates, but none of them fulfilled t
 - Support importing CSS in your components (with css modules enabled by default)
   - Note that CSS support will be a noop if you're using css-in-js
 - Testing with [Jest](https://facebook.github.io/jest/), using `react-scripts` from `create-react-app`
+- Sourcemap creation enabled by default
 - Thorough documentation written by someone who cares :heart_eyes:
 
 ## Walkthrough

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,11 +11,13 @@ export default {
   output: [
     {
       file: pkg.main,
-      format: 'cjs'
+      format: 'cjs',
+      sourcemap: true
     },
     {
       file: pkg.module,
-      format: 'es'
+      format: 'es',
+      sourcemap: true
     }
   ],
   plugins: [


### PR DESCRIPTION
As a followup, `source-map-explorer` could be added as suggested in
https://github.com/facebook/create-react-app/tree/next/packages/react-scripts/template#analyzing-the-bundle-size

Here's the PR that would allow CRA to support using the sourcemaps this PR generates: https://github.com/facebook/create-react-app/pull/2355

It was closed as stale due to lack of interest. Perhaps we can drum up some interest!